### PR TITLE
extend entitlement filtering to needToKnow and relTo

### DIFF
--- a/common-operating-picture/nifi/flows/working_flow.xml
+++ b/common-operating-picture/nifi/flows/working_flow.xml
@@ -33,7 +33,7 @@
                     <loadBalanceStatus>LOAD_BALANCE_NOT_CONFIGURED</loadBalanceStatus>
                     <loadBalanceStrategy>DO_NOT_LOAD_BALANCE</loadBalanceStrategy>
                     <name></name>
-                    <selectedRelationships>nano</selectedRelationships>
+                    <selectedRelationships>ztdf</selectedRelationships>
                     <source>
                         <groupId>68c325f8-6b46-3d72-0000-000000000000</groupId>
                         <id>ade07be9-021a-3c16-0000-000000000000</id>
@@ -142,7 +142,7 @@
                     <loadBalanceStatus>LOAD_BALANCE_NOT_CONFIGURED</loadBalanceStatus>
                     <loadBalanceStrategy>DO_NOT_LOAD_BALANCE</loadBalanceStrategy>
                     <name></name>
-                    <selectedRelationships>ztdf</selectedRelationships>
+                    <selectedRelationships>nano</selectedRelationships>
                     <source>
                         <groupId>68c325f8-6b46-3d72-0000-000000000000</groupId>
                         <id>ade07be9-021a-3c16-0000-000000000000</id>

--- a/common-operating-picture/nifi/sample_data/sample_files/vehicle-sample.json
+++ b/common-operating-picture/nifi/sample_data/sample_files/vehicle-sample.json
@@ -2,7 +2,7 @@
     "CompositeObject": [
         {
             "Type": "vehicles",
-            "tdfFormat": "nano",
+            "tdfFormat": "ztdf",
             "Details": {
                 "vehicleName": "F-35A Lightning II",
                 "callsign": "VPR01",
@@ -36,7 +36,7 @@
         },
         {
             "Type": "vehicles",
-            "tdfFormat": "nano",
+            "tdfFormat": "ztdf",
             "Details": {
                 "vehicleName": "B-52H Stratofortress",
                 "callsign": "IRON21",
@@ -70,7 +70,7 @@
         },
         {
             "Type": "vehicles",
-            "tdfFormat": "nano",
+            "tdfFormat": "ztdf",
             "Details": {
                 "vehicleName": "KC-135R Stratotanker",
                 "callsign": "TEXCO61",

--- a/common-operating-picture/nifi/sample_data/sample_files/vehicles-seed.json
+++ b/common-operating-picture/nifi/sample_data/sample_files/vehicles-seed.json
@@ -1,0 +1,276 @@
+{
+    "CompositeObject": [
+        {
+            "Type": "vehicles",
+            "tdfFormat": "ztdf",
+            "Details": {
+                "vehicleName": "F-35A Lightning II",
+                "callsign": "VPR01",
+                "registration": "USAF-4821",
+                "tailNumber": "19-5042",
+                "aircraft_type": "F-35A (FIGHTER)",
+                "operator": "USAF 422 SQN",
+                "origin": "NELLIS AFB",
+                "destination": "AO-BRV-12",
+                "speed": "450 kts",
+                "altitude": "FL350",
+                "heading": "090",
+                "Coord": "389531000N07745650000W",
+                "ProducerDateTimeLastChg": "2026-03-19T23:03:52Z",
+                "attrClassification": ["https://demo.com/attr/classification/value/unclassified"],
+                "attrRelTo": [],
+                "attrNeedToKnow": []
+            },
+            "Search": {
+                "attrRelTo": [],
+                "attrNeedToKnow": [],
+                "attrClassification": ["https://demo.com/attr/classification/value/unclassified"]
+            },
+            "Metadata": {
+                "callsign": "VPR01",
+                "speed": "450 kts",
+                "altitude": "FL350",
+                "heading": "090"
+            },
+            "EDH": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<edh:ExternalEdh xmlns:edh=\"urn:us:gov:ic:edh\" xmlns:arh=\"urn:us:gov:ic:arh\" xmlns:ism=\"urn:us:gov:ic:ism\" xmlns:icid=\"urn:us:gov:ic:id\" ism:DESVersion=\"201609.201707\" ism:ISMCATCESVersion=\"201709\">\n   <icid:Identifier>guide://unique-entity-id-vehicle-001</icid:Identifier>\n   <edh:DataItemCreateDateTime>2026-03-19T23:03:52Z</edh:DataItemCreateDateTime>\n   <edh:ResponsibleEntity edh:role=\"Custodian\">\n      <edh:Country>USA</edh:Country>\n      <edh:Organization>USAF</edh:Organization>\n   </edh:ResponsibleEntity>\n   <arh:Security ism:classification=\"U\" ism:ownerProducer=\"USA\" ism:disseminationControls=\"\" ism:resourceElement=\"true\" ism:compliesWith=\"USGov USIC\" ism:createDate=\"2026-03-19\" ism:derivativelyClassifiedBy=\"System\" ism:derivedFrom=\"Flight Ops\" ism:declassDate=\"2031-03-19\"/>\n</edh:ExternalEdh>"
+        },
+        {
+            "Type": "vehicles",
+            "tdfFormat": "ztdf",
+            "Details": {
+                "vehicleName": "B-52H Stratofortress",
+                "callsign": "IRON21",
+                "registration": "USAF-5512",
+                "tailNumber": "61-0034",
+                "aircraft_type": "B-52H (BOMBER)",
+                "operator": "USAF 2 BW",
+                "origin": "BARKSDALE AFB",
+                "destination": "AO-BRAVO",
+                "speed": "525 kts",
+                "altitude": "FL400",
+                "heading": "045",
+                "Coord": "414500000N08730000000W",
+                "ProducerDateTimeLastChg": "2026-03-19T23:03:52Z",
+                "attrClassification": ["https://demo.com/attr/classification/value/confidential"],
+                "attrRelTo": ["https://demo.com/attr/relto/value/gbr", "https://demo.com/attr/relto/value/fvey", "https://demo.com/attr/relto/value/aus", "https://demo.com/attr/relto/value/nzl"],
+                "attrNeedToKnow": []
+            },
+            "Search": {
+                "attrRelTo": ["https://demo.com/attr/relto/value/gbr", "https://demo.com/attr/relto/value/fvey", "https://demo.com/attr/relto/value/aus", "https://demo.com/attr/relto/value/nzl"],
+                "attrNeedToKnow": [],
+                "attrClassification": ["https://demo.com/attr/classification/value/confidential"]
+            },
+            "Metadata": {
+                "callsign": "IRON21",
+                "speed": "525 kts",
+                "altitude": "FL400",
+                "heading": "045"
+            },
+            "EDH": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<edh:ExternalEdh xmlns:edh=\"urn:us:gov:ic:edh\" xmlns:arh=\"urn:us:gov:ic:arh\" xmlns:ism=\"urn:us:gov:ic:ism\" xmlns:icid=\"urn:us:gov:ic:id\" ism:DESVersion=\"201609.201707\" ism:ISMCATCESVersion=\"201709\">\n   <icid:Identifier>guide://unique-entity-id-vehicle-002</icid:Identifier>\n   <edh:DataItemCreateDateTime>2026-03-19T23:03:52Z</edh:DataItemCreateDateTime>\n   <edh:ResponsibleEntity edh:role=\"Custodian\">\n      <edh:Country>USA</edh:Country>\n      <edh:Organization>USAF</edh:Organization>\n   </edh:ResponsibleEntity>\n   <arh:Security ism:classification=\"C\" ism:ownerProducer=\"USA\" ism:releasableTo=\"USA GBR CAN AUS NZL\" ism:disseminationControls=\"\" ism:resourceElement=\"true\" ism:compliesWith=\"USGov USIC\" ism:createDate=\"2026-03-19\" ism:derivativelyClassifiedBy=\"System\" ism:derivedFrom=\"Flight Ops\" ism:declassDate=\"2031-03-19\"/>\n</edh:ExternalEdh>"
+        },
+        {
+            "Type": "vehicles",
+            "tdfFormat": "ztdf",
+            "Details": {
+                "vehicleName": "KC-135R Stratotanker",
+                "callsign": "TEXCO61",
+                "registration": "USAF-6190",
+                "tailNumber": "62-3547",
+                "aircraft_type": "KC-135R (TANKER)",
+                "operator": "USAF 340 WG",
+                "origin": "AL UDEID AB",
+                "destination": "ORBIT TRACK ALPHA",
+                "speed": "480 kts",
+                "altitude": "FL280",
+                "heading": "180",
+                "Coord": "251700000N05131000000E",
+                "ProducerDateTimeLastChg": "2026-03-19T23:03:52Z",
+                "attrClassification": ["https://demo.com/attr/classification/value/secret"],
+                "attrRelTo": ["https://demo.com/attr/relto/value/gbr", "https://demo.com/attr/relto/value/fra", "https://demo.com/attr/relto/value/deu"],
+                "attrNeedToKnow": []
+            },
+            "Search": {
+                "attrRelTo": ["https://demo.com/attr/relto/value/gbr", "https://demo.com/attr/relto/value/fra", "https://demo.com/attr/relto/value/deu"],
+                "attrNeedToKnow": [],
+                "attrClassification": ["https://demo.com/attr/classification/value/secret"]
+            },
+            "Metadata": {
+                "callsign": "TEXCO61",
+                "speed": "480 kts",
+                "altitude": "FL280",
+                "heading": "180"
+            },
+            "EDH": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<edh:ExternalEdh xmlns:edh=\"urn:us:gov:ic:edh\" xmlns:arh=\"urn:us:gov:ic:arh\" xmlns:ism=\"urn:us:gov:ic:ism\" xmlns:icid=\"urn:us:gov:ic:id\" ism:DESVersion=\"201609.201707\" ism:ISMCATCESVersion=\"201709\">\n   <icid:Identifier>guide://unique-entity-id-vehicle-003</icid:Identifier>\n   <edh:DataItemCreateDateTime>2026-03-19T23:03:52Z</edh:DataItemCreateDateTime>\n   <edh:ResponsibleEntity edh:role=\"Custodian\">\n      <edh:Country>USA</edh:Country>\n      <edh:Organization>USAF</edh:Organization>\n   </edh:ResponsibleEntity>\n   <arh:Security ism:classification=\"S\" ism:ownerProducer=\"USA\" ism:releasableTo=\"USA GBR FRA DEU\" ism:disseminationControls=\"\" ism:resourceElement=\"true\" ism:compliesWith=\"USGov USIC\" ism:createDate=\"2026-03-19\" ism:derivativelyClassifiedBy=\"System\" ism:derivedFrom=\"ATO Tasking\" ism:declassDate=\"2031-03-19\"/>\n</edh:ExternalEdh>"
+        },
+        {
+            "Type": "vehicles",
+            "tdfFormat": "ztdf",
+            "Details": {
+                "vehicleName": "MQ-9A Reaper",
+                "callsign": "HAWK03",
+                "registration": "USAF-7733",
+                "tailNumber": "21-0087",
+                "aircraft_type": "MQ-9A (UAV)",
+                "operator": "USAF 432 WG",
+                "origin": "CREECH AFB",
+                "destination": "AO-KNX-05",
+                "speed": "210 kts",
+                "altitude": "FL250",
+                "heading": "270",
+                "Coord": "361500000N11546000000W",
+                "ProducerDateTimeLastChg": "2026-03-19T23:03:52Z",
+                "attrClassification": ["https://demo.com/attr/classification/value/topsecret"],
+                "attrRelTo": ["https://demo.com/attr/relto/value/gbr", "https://demo.com/attr/relto/value/can", "https://demo.com/attr/relto/value/aus", "https://demo.com/attr/relto/value/nzl"],
+                "attrNeedToKnow": []
+            },
+            "Search": {
+                "attrRelTo": ["https://demo.com/attr/relto/value/gbr", "https://demo.com/attr/relto/value/can", "https://demo.com/attr/relto/value/aus", "https://demo.com/attr/relto/value/nzl"],
+                "attrNeedToKnow": [],
+                "attrClassification": ["https://demo.com/attr/classification/value/topsecret"]
+            },
+            "Metadata": {
+                "callsign": "HAWK03",
+                "speed": "210 kts",
+                "altitude": "FL250",
+                "heading": "270"
+            },
+            "EDH": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<edh:ExternalEdh xmlns:edh=\"urn:us:gov:ic:edh\" xmlns:arh=\"urn:us:gov:ic:arh\" xmlns:ism=\"urn:us:gov:ic:ism\" xmlns:icid=\"urn:us:gov:ic:id\" ism:DESVersion=\"201609.201707\" ism:ISMCATCESVersion=\"201709\">\n   <icid:Identifier>guide://unique-entity-id-vehicle-004</icid:Identifier>\n   <edh:DataItemCreateDateTime>2026-03-19T23:03:52Z</edh:DataItemCreateDateTime>\n   <edh:ResponsibleEntity edh:role=\"Custodian\">\n      <edh:Country>USA</edh:Country>\n      <edh:Organization>USAF</edh:Organization>\n   </edh:ResponsibleEntity>\n   <arh:Security ism:classification=\"TS\" ism:ownerProducer=\"USA\" ism:releasableTo=\"USA GBR CAN AUS NZL\" ism:disseminationControls=\"NF\" ism:resourceElement=\"true\" ism:compliesWith=\"USGov USIC\" ism:createDate=\"2026-03-19\" ism:derivativelyClassifiedBy=\"System\" ism:derivedFrom=\"ISR Tasking\" ism:declassDate=\"2031-03-19\"/>\n</edh:ExternalEdh>"
+        },
+        {
+            "Type": "vehicles",
+            "tdfFormat": "ztdf",
+            "Details": {
+                "vehicleName": "E-3 Sentry AWACS",
+                "callsign": "MAGIC01",
+                "registration": "USAF-8841",
+                "tailNumber": "77-0354",
+                "aircraft_type": "E-3G (AEW&C)",
+                "operator": "USAF 552 ACW",
+                "origin": "TINKER AFB",
+                "destination": "CAP BRAVO",
+                "speed": "400 kts",
+                "altitude": "FL290",
+                "heading": "135",
+                "Coord": "482300000N01325000000E",
+                "ProducerDateTimeLastChg": "2026-03-19T23:03:52Z",
+                "attrClassification": ["https://demo.com/attr/classification/value/confidential"],
+                "attrRelTo": ["https://demo.com/attr/relto/value/jpn"],
+                "attrNeedToKnow": []
+            },
+            "Search": {
+                "attrRelTo": ["https://demo.com/attr/relto/value/jpn"],
+                "attrNeedToKnow": [],
+                "attrClassification": ["https://demo.com/attr/classification/value/confidential"]
+            },
+            "Metadata": {
+                "callsign": "MAGIC01",
+                "speed": "400 kts",
+                "altitude": "FL290",
+                "heading": "135"
+            },
+            "EDH": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<edh:ExternalEdh xmlns:edh=\"urn:us:gov:ic:edh\" xmlns:arh=\"urn:us:gov:ic:arh\" xmlns:ism=\"urn:us:gov:ic:ism\" xmlns:icid=\"urn:us:gov:ic:id\" ism:DESVersion=\"201609.201707\" ism:ISMCATCESVersion=\"201709\">\n   <icid:Identifier>guide://unique-entity-id-vehicle-005</icid:Identifier>\n   <edh:DataItemCreateDateTime>2026-03-19T23:03:52Z</edh:DataItemCreateDateTime>\n   <edh:ResponsibleEntity edh:role=\"Custodian\">\n      <edh:Country>USA</edh:Country>\n      <edh:Organization>USAF</edh:Organization>\n   </edh:ResponsibleEntity>\n   <arh:Security ism:classification=\"C\" ism:ownerProducer=\"USA\" ism:releasableTo=\"USA JPN\" ism:disseminationControls=\"\" ism:resourceElement=\"true\" ism:compliesWith=\"USGov USIC\" ism:createDate=\"2026-03-19\" ism:derivativelyClassifiedBy=\"System\" ism:derivedFrom=\"C2 Ops\" ism:declassDate=\"2031-03-19\"/>\n</edh:ExternalEdh>"
+        },
+        {
+            "Type": "vehicles",
+            "tdfFormat": "ztdf",
+            "Details": {
+                "vehicleName": "C-17A Globemaster III",
+                "callsign": "REACH44",
+                "registration": "AMC-3302",
+                "tailNumber": "03-3119",
+                "aircraft_type": "C-17A (TRANSPORT)",
+                "operator": "AMC 62 AW",
+                "origin": "MCCHORD AFB",
+                "destination": "RAMSTEIN AB",
+                "speed": "490 kts",
+                "altitude": "FL370",
+                "heading": "060",
+                "Coord": "512100000N00030000000W",
+                "ProducerDateTimeLastChg": "2026-03-19T23:03:52Z",
+                "attrClassification": ["https://demo.com/attr/classification/value/unclassified"],
+                "attrRelTo": ["https://demo.com/attr/relto/value/gbr", "https://demo.com/attr/relto/value/can", "https://demo.com/attr/relto/value/aus"],
+                "attrNeedToKnow": []
+            },
+            "Search": {
+                "attrRelTo": ["https://demo.com/attr/relto/value/gbr", "https://demo.com/attr/relto/value/can", "https://demo.com/attr/relto/value/aus"],
+                "attrNeedToKnow": [],
+                "attrClassification": ["https://demo.com/attr/classification/value/unclassified"]
+            },
+            "Metadata": {
+                "callsign": "REACH44",
+                "speed": "490 kts",
+                "altitude": "FL370",
+                "heading": "060"
+            },
+            "EDH": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<edh:ExternalEdh xmlns:edh=\"urn:us:gov:ic:edh\" xmlns:arh=\"urn:us:gov:ic:arh\" xmlns:ism=\"urn:us:gov:ic:ism\" xmlns:icid=\"urn:us:gov:ic:id\" ism:DESVersion=\"201609.201707\" ism:ISMCATCESVersion=\"201709\">\n   <icid:Identifier>guide://unique-entity-id-vehicle-006</icid:Identifier>\n   <edh:DataItemCreateDateTime>2026-03-19T23:03:52Z</edh:DataItemCreateDateTime>\n   <edh:ResponsibleEntity edh:role=\"Custodian\">\n      <edh:Country>USA</edh:Country>\n      <edh:Organization>AMC</edh:Organization>\n   </edh:ResponsibleEntity>\n   <arh:Security ism:classification=\"U\" ism:ownerProducer=\"USA\" ism:releasableTo=\"USA GBR CAN AUS\" ism:disseminationControls=\"\" ism:resourceElement=\"true\" ism:compliesWith=\"USGov USIC\" ism:createDate=\"2026-03-19\" ism:derivativelyClassifiedBy=\"System\" ism:derivedFrom=\"Airlift Ops\" ism:declassDate=\"2031-03-19\"/>\n</edh:ExternalEdh>"
+        },
+        {
+            "Type": "vehicles",
+            "tdfFormat": "ztdf",
+            "Details": {
+                "vehicleName": "P-8A Poseidon",
+                "callsign": "NEPTUNE7",
+                "registration": "USN-9921",
+                "tailNumber": "169329",
+                "aircraft_type": "P-8A (MPA)",
+                "operator": "USN VP-16",
+                "origin": "NAS JACKSONVILLE",
+                "destination": "PATROL ZONE DELTA",
+                "speed": "440 kts",
+                "altitude": "FL200",
+                "heading": "315",
+                "Coord": "352000000N06200000000W",
+                "ProducerDateTimeLastChg": "2026-03-19T23:03:52Z",
+                "attrClassification": ["https://demo.com/attr/classification/value/secret"],
+                "attrRelTo": ["https://demo.com/attr/relto/value/gbr", "https://demo.com/attr/relto/value/can", "https://demo.com/attr/relto/value/aus", "https://demo.com/attr/relto/value/nzl"],
+                "attrNeedToKnow": []
+            },
+            "Search": {
+                "attrRelTo": ["https://demo.com/attr/relto/value/gbr", "https://demo.com/attr/relto/value/can", "https://demo.com/attr/relto/value/aus", "https://demo.com/attr/relto/value/nzl"],
+                "attrNeedToKnow": [],
+                "attrClassification": ["https://demo.com/attr/classification/value/secret"]
+            },
+            "Metadata": {
+                "callsign": "NEPTUNE7",
+                "speed": "440 kts",
+                "altitude": "FL200",
+                "heading": "315"
+            },
+            "EDH": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<edh:ExternalEdh xmlns:edh=\"urn:us:gov:ic:edh\" xmlns:arh=\"urn:us:gov:ic:arh\" xmlns:ism=\"urn:us:gov:ic:ism\" xmlns:icid=\"urn:us:gov:ic:id\" ism:DESVersion=\"201609.201707\" ism:ISMCATCESVersion=\"201709\">\n   <icid:Identifier>guide://unique-entity-id-vehicle-007</icid:Identifier>\n   <edh:DataItemCreateDateTime>2026-03-19T23:03:52Z</edh:DataItemCreateDateTime>\n   <edh:ResponsibleEntity edh:role=\"Custodian\">\n      <edh:Country>USA</edh:Country>\n      <edh:Organization>USN</edh:Organization>\n   </edh:ResponsibleEntity>\n   <arh:Security ism:classification=\"S\" ism:ownerProducer=\"USA\" ism:releasableTo=\"USA GBR CAN AUS NZL\" ism:disseminationControls=\"\" ism:resourceElement=\"true\" ism:compliesWith=\"USGov USIC\" ism:createDate=\"2026-03-19\" ism:derivativelyClassifiedBy=\"System\" ism:derivedFrom=\"Maritime Patrol\" ism:declassDate=\"2031-03-19\"/>\n</edh:ExternalEdh>"
+        },
+        {
+            "Type": "vehicles",
+            "tdfFormat": "ztdf",
+            "Details": {
+                "vehicleName": "RC-135V Rivet Joint",
+                "callsign": "COBRA11",
+                "registration": "USAF-2201",
+                "tailNumber": "64-14841",
+                "aircraft_type": "RC-135V (ISR)",
+                "operator": "USAF 55 WG",
+                "origin": "OFFUTT AFB",
+                "destination": "ORBIT TRACK ECHO",
+                "speed": "460 kts",
+                "altitude": "FL310",
+                "heading": "000",
+                "Coord": "435000000N03300000000E",
+                "ProducerDateTimeLastChg": "2026-03-19T23:03:52Z",
+                "attrClassification": ["https://demo.com/attr/classification/value/topsecret"],
+                "attrRelTo": ["https://demo.com/attr/relto/value/gbr", "https://demo.com/attr/relto/value/can"],
+                "attrNeedToKnow": []
+            },
+            "Search": {
+                "attrRelTo": ["https://demo.com/attr/relto/value/gbr", "https://demo.com/attr/relto/value/can"],
+                "attrNeedToKnow": [],
+                "attrClassification": ["https://demo.com/attr/classification/value/topsecret"]
+            },
+            "Metadata": {
+                "callsign": "COBRA11",
+                "speed": "460 kts",
+                "altitude": "FL310",
+                "heading": "000"
+            },
+            "EDH": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<edh:ExternalEdh xmlns:edh=\"urn:us:gov:ic:edh\" xmlns:arh=\"urn:us:gov:ic:arh\" xmlns:ism=\"urn:us:gov:ic:ism\" xmlns:icid=\"urn:us:gov:ic:id\" ism:DESVersion=\"201609.201707\" ism:ISMCATCESVersion=\"201709\">\n   <icid:Identifier>guide://unique-entity-id-vehicle-008</icid:Identifier>\n   <edh:DataItemCreateDateTime>2026-03-19T23:03:52Z</edh:DataItemCreateDateTime>\n   <edh:ResponsibleEntity edh:role=\"Custodian\">\n      <edh:Country>USA</edh:Country>\n      <edh:Organization>USAF</edh:Organization>\n   </edh:ResponsibleEntity>\n   <arh:Security ism:classification=\"TS\" ism:ownerProducer=\"USA\" ism:releasableTo=\"USA GBR CAN\" ism:disseminationControls=\"NF\" ism:resourceElement=\"true\" ism:compliesWith=\"USGov USIC\" ism:createDate=\"2026-03-19\" ism:derivativelyClassifiedBy=\"System\" ism:derivedFrom=\"SIGINT Tasking\" ism:declassDate=\"2031-03-19\"/>\n</edh:ExternalEdh>"
+        }
+    ]
+}

--- a/common-operating-picture/ui/src/components/Banner.tsx
+++ b/common-operating-picture/ui/src/components/Banner.tsx
@@ -54,7 +54,7 @@ export const Banner = () => {
 
   const { label, color } = getBannerData();
 
-  if ( activeEntitlements.size === 0) return null;
+  if (activeEntitlements.size === 0 || activeEntitlements.has('NoAccess')) return null;
 
   return (
     <Box

--- a/common-operating-picture/ui/src/components/JsonSchemaForm/ErrorListTemplate.tsx
+++ b/common-operating-picture/ui/src/components/JsonSchemaForm/ErrorListTemplate.tsx
@@ -1,9 +1,24 @@
-import { Alert } from '@mui/material';
+import { Alert, List, ListItem, ListItemText } from '@mui/material';
+import { ErrorListProps, RJSFSchema, FormContextType, StrictRJSFSchema } from '@rjsf/utils';
 
-export function ErrorListTemplate() {
+export function ErrorListTemplate<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F extends FormContextType = any,
+>({ errors }: ErrorListProps<T, S, F>) {
   return (
-    <Alert variant="filled" severity="error" sx={{ marginTop: '1.5em' }}>
-      Please correct the errors in the form before submitting.
+    <Alert variant="filled" severity="error" sx={{ mt: 2 }}>
+      <strong>Please fix the following errors:</strong>
+      <List dense disablePadding sx={{ mt: 0.5 }}>
+        {errors.map((error, i) => (
+          <ListItem key={i} disableGutters sx={{ py: 0 }}>
+            <ListItemText
+              primary={`${error.property?.replace(/^\./, '') || 'Field'}: ${error.message}`}
+              primaryTypographyProps={{ variant: 'body2', color: 'inherit' }}
+            />
+          </ListItem>
+        ))}
+      </List>
     </Alert>
   );
 }

--- a/common-operating-picture/ui/src/components/Map/CopMap.tsx
+++ b/common-operating-picture/ui/src/components/Map/CopMap.tsx
@@ -20,6 +20,7 @@ interface CopMapProps {
   onPopOut: (response: VehiclePopOutResponse) => void;
 }
 
+
 export function CopMap({
   filteredVehicleData,
   tdfObjects,
@@ -28,6 +29,7 @@ export function CopMap({
   onVehicleClick,
   onPopOut,
 }: CopMapProps) {
+
   const { trails, updateTrails } = useVehicleTrails({
     maxPoints: 5000,
     minInterval: 2000,
@@ -98,9 +100,7 @@ export function CopMap({
           </LayersControl.Overlay>
         )}
         {tdfObjects.length > 0 && (
-          <LayersControl.Overlay name="TDF Objects" checked>
-            <TdfObjectsMapLayer tdfObjects={tdfObjects} />
-          </LayersControl.Overlay>
+          <TdfObjectsMapLayer tdfObjects={tdfObjects} />
         )}
       </LayersControl>
     </MapContainer>

--- a/common-operating-picture/ui/src/components/Map/MarkerLayer.tsx
+++ b/common-operating-picture/ui/src/components/Map/MarkerLayer.tsx
@@ -1,7 +1,7 @@
 import { LayerGroup, LayersControl, Marker, Popup } from 'react-leaflet';
 import L from 'leaflet';
 import { TdfObjectResponse } from '@/hooks/useRpcClient';
-import { Box, Stack, Typography } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 import { useSourceType } from '@/pages/SourceTypes/SourceTypeContext';
 import { formatDateTime } from '@/utils/format';
 import { mapColors, mapIcons, mapStringToColor, mapStringToSvgPath } from '@/pages/SourceTypes/helpers/markers';
@@ -45,30 +45,32 @@ export function MarkerLayer({ tdfObjects = [], isCluster = false, layerName = 'u
       : value;
 
     return (
-      <Stack direction="column" gap={0} spacing={0} mb={1} sx={{ minWidth: '350px' }}>
-        <Typography variant="h6" sx={{ wordBreak: 'break-word', lineHeight: 1.2 }}>
+      <Box className="tooltip-header" sx={{ mt: 1 }}>
+        <Typography variant="h6" className="vehicle-name" sx={{ pr: 2 }}>
           {getFieldTitle(displayFields?.header)}: {displayValue}
         </Typography>
-        <Typography variant="body2" sx={{ color: 'text.secondary' }}>
-          {formattedDateTime}
-        </Typography>
-      </Stack>
+        <Box className="callsign-container">
+          <Typography variant="caption" className="callsign-label">Time:</Typography>
+          <Typography variant="caption" className="callsign-value">{formattedDateTime}</Typography>
+        </Box>
+      </Box>
     );
   };
 
   const renderDetails = (o: TdfObjectResponse) => {
     const oa = propertyOf(o.decryptedData);
 
-    const details = (displayFields?.details || []).map(field => {
+    const details = (displayFields?.details || []).filter(field => !field.startsWith('attr')).map(field => {
       let value = oa(field);
 
       if (value && typeof value === 'object' && !Array.isArray(value)) {
-      value = value.country || value.name || JSON.stringify(value);
+        value = value.country || value.name || JSON.stringify(value);
       }
 
       return (
-        <Box key={`${o.tdfObject.id}-${field}-details`} sx={{ wordBreak: 'break-all' }}>
-          <strong>{getFieldTitle(field)}</strong>: {value}
+        <Box key={`${o.tdfObject.id}-${field}-details`} className="detail-item">
+          <Typography variant="caption" className="detail-label">{getFieldTitle(field)}:</Typography>
+          <Typography variant="caption" className="detail-value">{value || 'N/A'}</Typography>
         </Box>
       );
     });
@@ -145,7 +147,7 @@ export function MarkerLayer({ tdfObjects = [], isCluster = false, layerName = 'u
         objectConfigValueColor = objectConfigValueColor.toLowerCase();
       }
 
-      iconColor = mapStringToColor(objectConfigValueColor);
+      iconColor = objectConfigValueColor ? mapStringToColor(objectConfigValueColor) : mapColors[mapFields.colorDefault] || mapColors.default;
     }
 
     if (!iconColor){
@@ -225,8 +227,8 @@ export function MarkerLayer({ tdfObjects = [], isCluster = false, layerName = 'u
 
       return (
         <Marker position={{ lat: coordinates[1], lng: coordinates[0] }} key={tdfObject.tdfObject.id} icon={dynamicTdfIcon}>
-          <Popup minWidth={380} maxWidth={500}>
-            <Box sx={{ p: 1, display: 'block', width: '100%', overflow: 'hidden' }}>
+          <Popup minWidth={340} maxWidth={400} offset={[0, -15]} className="custom-vehicle-popup" closeButton={false}>
+            <Box className="tooltip-container" sx={{ position: 'relative', paddingBottom: '4px', maxHeight: '70vh', overflowY: 'auto' }}>
               <ObjectBanner
                 objClassification={objClass.length > 0 ? objClass : ['UNCLASSIFIED']}
                 objNTK={objNTK}
@@ -234,8 +236,9 @@ export function MarkerLayer({ tdfObjects = [], isCluster = false, layerName = 'u
                 notes={[]}
               />
               {renderHeader(tdfObject)}
-              <Box sx={{ mt: 1 }}>
-              {renderDetails(tdfObject)}
+              <Box className="tooltip-section">
+                <Typography variant="body2" className="section-title">Details</Typography>
+                {renderDetails(tdfObject)}
               </Box>
             </Box>
           </Popup>

--- a/common-operating-picture/ui/src/components/Map/TdfObjectsMapLayer.tsx
+++ b/common-operating-picture/ui/src/components/Map/TdfObjectsMapLayer.tsx
@@ -1,4 +1,4 @@
-import { LayerGroup } from 'react-leaflet';
+import { LayerGroup, LayersControl } from 'react-leaflet';
 import { TdfObjectResponse } from '@/hooks/useRpcClient';
 import { ClusterLayer } from '@/components/Map/ClusterLayer';
 import { MarkerLayer } from '@/components/Map/MarkerLayer';
@@ -10,7 +10,7 @@ type Props = {
 
 
 export function TdfObjectsMapLayer({ tdfObjects = [] }: Props) {
-  const { mapFields } = useSourceType();
+  const { id, mapFields } = useSourceType();
 
   const groupTdfObjectsByDecryptedDataProperty = (arr:TdfObjectResponse[], property:string) => {
 
@@ -34,19 +34,23 @@ export function TdfObjectsMapLayer({ tdfObjects = [] }: Props) {
   const clusterEnabled = false;
   if (clusterEnabled){
     return (
-      <LayerGroup>
-        {layersToRender.map( key => (
-          <ClusterLayer tdfObjects={groupedTDFObjects[key]} key={`cluster-layer-${key}`} layerName={key}/>
-        ))}
-      </LayerGroup>
+      <LayersControl.Overlay checked name={id} key={id}>
+        <LayerGroup>
+          {layersToRender.map( key => (
+            <ClusterLayer tdfObjects={groupedTDFObjects[key]} key={`cluster-layer-${key}`} layerName={key}/>
+          ))}
+        </LayerGroup>
+      </LayersControl.Overlay>
     );
   } else {
     return (
-      <LayerGroup>
-        {layersToRender.map( key => (
-          <MarkerLayer tdfObjects={groupedTDFObjects[key]} key={`layer-${key}`} layerName={key}/>
-        ))}
-      </LayerGroup>
+      <LayersControl.Overlay checked name={id} key={id}>
+        <LayerGroup>
+          {layersToRender.map( key => (
+            <MarkerLayer tdfObjects={groupedTDFObjects[key]} key={`layer-${key}`} layerName={key} isCluster/>
+          ))}
+        </LayerGroup>
+      </LayersControl.Overlay>
     );
   }
 }

--- a/common-operating-picture/ui/src/hooks/useVehicleData.ts
+++ b/common-operating-picture/ui/src/hooks/useVehicleData.ts
@@ -1,8 +1,7 @@
 import { useState, useCallback, useEffect, useMemo, useContext } from 'react';
 import { useRpcClient } from '@/hooks/useRpcClient';
 import { BannerContext } from '@/contexts/BannerContext';
-import { TimestampSelector } from '@/proto/tdf_object/v1/tdf_object_pb';
-import { SrcType } from '@/proto/tdf_object/v1/tdf_object_pb';
+import { SrcType, TimestampSelector } from '@/proto/tdf_object/v1/tdf_object_pb';
 import { Timestamp } from '@bufbuild/protobuf';
 import { VehicleData } from '@/types/vehicle';
 import dayjs from 'dayjs';
@@ -10,7 +9,12 @@ import dayjs from 'dayjs';
 const VEHICLE_SRC_TYPE_ID = 'vehicles';
 const POLL_INTERVAL_MS = 1000;
 
-export function useVehicleData() {
+export type VehicleDateFilter = {
+  startDate?: string;
+  endDate?: string;
+};
+
+export function useVehicleData(dateFilter?: VehicleDateFilter, pollingEnabled = true) {
   const { getSrcType, queryTdfObjectsLight } = useRpcClient();
   const { activeEntitlements } = useContext(BannerContext);
 
@@ -23,17 +27,38 @@ export function useVehicleData() {
     }
 
     return vehicleData.filter((vehicle) => {
+      // Classification check (all-of)
       const classification = vehicle.data?.attrClassification;
-      if (!classification) return true;
-      const classStr = Array.isArray(classification) ? classification[0] : classification;
-      return classStr ? activeEntitlements.has(classStr) : true;
+      if (classification) {
+        const classStr = Array.isArray(classification) ? classification[0] : classification;
+        if (classStr && !activeEntitlements.has(classStr)) return false;
+      }
+
+      // NeedToKnow check (all-of — user must have every attribute)
+      const needToKnow = vehicle.data?.attrNeedToKnow || [];
+      for (const ntk of needToKnow) {
+        if (ntk && !activeEntitlements.has(ntk)) return false;
+      }
+
+      // RelTo check (any-of — user must have at least one)
+      const relTo = vehicle.data?.attrRelTo || [];
+      if (relTo.length > 0 && !relTo.some(rel => activeEntitlements.has(rel))) {
+        return false;
+      }
+
+      return true;
     });
   }, [vehicleData, activeEntitlements]);
 
   const fetchVehicles = useCallback(async () => {
     try {
       const tsRange = new TimestampSelector();
-      tsRange.greaterOrEqualTo = Timestamp.fromDate(dayjs().subtract(24, 'hour').toDate());
+      tsRange.greaterOrEqualTo = dateFilter?.startDate
+        ? Timestamp.fromDate(dayjs(dateFilter.startDate).toDate())
+        : Timestamp.fromDate(new Date(0));
+      if (dateFilter?.endDate) {
+        tsRange.lesserOrEqualTo = Timestamp.fromDate(dayjs(dateFilter.endDate).toDate());
+      }
 
       const response = await queryTdfObjectsLight({
         srcType: VEHICLE_SRC_TYPE_ID,
@@ -73,7 +98,7 @@ export function useVehicleData() {
       console.error('Error fetching vehicles:', error);
       setVehicleData([]);
     }
-  }, [queryTdfObjectsLight]);
+  }, [queryTdfObjectsLight, dateFilter?.startDate, dateFilter?.endDate]);
 
   // Fetch vehicle source type schema once
   useEffect(() => {
@@ -98,9 +123,10 @@ export function useVehicleData() {
 
   // Poll for updates
   useEffect(() => {
+    if (!pollingEnabled) return;
     const intervalId = setInterval(fetchVehicles, POLL_INTERVAL_MS);
     return () => clearInterval(intervalId);
-  }, [fetchVehicles]);
+  }, [fetchVehicles, pollingEnabled]);
 
   return {
     filteredVehicleData,

--- a/common-operating-picture/ui/src/pages/SourceTypes/SearchFilter.tsx
+++ b/common-operating-picture/ui/src/pages/SourceTypes/SearchFilter.tsx
@@ -5,7 +5,7 @@ import { Alert, Backdrop, Box, Button, CircularProgress, Popover } from '@mui/ma
 import { FilterAlt } from '@mui/icons-material';
 import { useSourceType } from './SourceTypeContext';
 import { ErrorListTemplate } from '@/components/JsonSchemaForm/ErrorListTemplate';
-import { RJSFSchema } from '@rjsf/utils';
+import { RJSFSchema, RJSFValidationError } from '@rjsf/utils';
 import Form, { IChangeEvent, withTheme } from '@rjsf/core';
 import { Theme as RJSFFormMuiTheme } from '@rjsf/mui';
 import { customizeValidator } from '@rjsf/validator-ajv8';
@@ -21,6 +21,15 @@ import { checkAndSetUnavailableAttributes, checkObjectEntitlements } from '@/uti
 const validator = customizeValidator<any>();
 const SearchForm = withTheme<any, RJSFSchema>(RJSFFormMuiTheme);
 
+function transformErrors(errors: RJSFValidationError[]) {
+  return errors.map(error => {
+    if (error.name === 'required') {
+      return { ...error, message: 'This field is required' };
+    }
+    return error;
+  });
+}
+
 type QueryParamState = {
   formData: any;
   mapState: {
@@ -31,9 +40,10 @@ type QueryParamState = {
 
 type Props = {
   map: Map | null;
+  onDateFilter?: (dates: { startDate?: string; endDate?: string }) => void;
 }
 
-export function SearchFilter({ map }: Props) { //onSearch removed
+export function SearchFilter({ map, onDateFilter }: Props) { //onSearch removed
   const [menuAnchorEl, setMenuAnchorEl] = useState<HTMLButtonElement | null>(null);
   const [searchParams, setSearchParams] = useSearchParams();
 
@@ -67,6 +77,20 @@ export function SearchFilter({ map }: Props) { //onSearch removed
   // Handler to close the menu, restoring original banner state
   const handleCancel = () => {
     setMenuAnchorEl(null); // Close the popover
+  };
+
+  const handleClear = () => {
+    setFormData({});
+    setHasResults(false);
+    setTdfObjects([]);
+    setMenuAnchorEl(null);
+    if (onDateFilter) {
+      onDateFilter({});
+    }
+    setSearchParams(params => {
+      params.delete('q');
+      return params;
+    });
   };
 
   const { geoField, attrFields } = useSourceType();
@@ -180,6 +204,10 @@ export function SearchFilter({ map }: Props) { //onSearch removed
         return;
     }
 
+    if (onDateFilter) {
+      onDateFilter({ startDate: searchFormData.startDate, endDate: searchFormData.endDate });
+    }
+
     try {
       setError('');
       setLoading(true);
@@ -282,13 +310,17 @@ export function SearchFilter({ map }: Props) { //onSearch removed
             validator={validator}
             onChange={handleChange}
             onSubmit={handleSearch}
+            transformErrors={transformErrors}
             templates={{ ErrorListTemplate }}
             noHtml5Validate
           />
-          <Button variant="contained" onClick={() => formRef.current?.submit()} sx={{ mt: 2 }}>
-            Search
-          </Button>
-          <Button onClick={handleCancel}>Cancel</Button>
+          <Box display="flex" gap={1} mt={2}>
+            <Button variant="contained" onClick={() => formRef.current?.submit()}>
+              Search
+            </Button>
+            <Button onClick={handleClear}>Clear</Button>
+            <Button onClick={handleCancel}>Cancel</Button>
+          </Box>
           <Backdrop open={loading} sx={{ position: 'absolute', zIndex: 10 }}>
             <Box display="flex" alignItems="center" gap={1}>
               <CircularProgress size={35} thickness={8} /> loading...

--- a/common-operating-picture/ui/src/pages/SourceTypes/SourceTypeProvider.tsx
+++ b/common-operating-picture/ui/src/pages/SourceTypes/SourceTypeProvider.tsx
@@ -87,6 +87,7 @@ export function SourceTypeProvider({ children, srcType }: Props) {
 
     const searchFormSchema: RJSFSchema = {
       type: 'object',
+      required: ['startDate', 'endDate'],
       definitions: createFormSchema.definitions,
       properties: {
         startDate: {
@@ -143,7 +144,7 @@ export function SourceTypeProvider({ children, srcType }: Props) {
   }, [srcType]);
 
   if (!srcType) {
-    return null;
+    return <>{children}</>;
   }
 
   const { geoField, searchFields, tsField, attrFields, displayFields, mapFields } = srcType.metadata || {};

--- a/common-operating-picture/ui/src/pages/SourceTypes/SourceTypeSelector.tsx
+++ b/common-operating-picture/ui/src/pages/SourceTypes/SourceTypeSelector.tsx
@@ -1,6 +1,9 @@
-import React, { useEffect, useState } from 'react';
-import { Button, Menu, MenuItem } from '@mui/material';
-import { ExpandLess, ExpandMore } from '@mui/icons-material';
+import React, { useEffect, useRef, useState } from 'react';
+import { Chip, ListItemIcon, ListItemText, Menu, MenuItem, Typography } from '@mui/material';
+import {
+  Check, ExpandLess, ExpandMore,
+  Flight, People, Business, Assessment, Category,
+} from '@mui/icons-material';
 import { useRpcClient } from '@/hooks/useRpcClient';
 
 interface Props {
@@ -9,10 +12,10 @@ interface Props {
 }
 
 export function SourceTypeSelector({ value, onChange }: Props) {
-  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
-  const open = Boolean(anchorEl);
-  const openMenu = (e: React.MouseEvent<HTMLButtonElement>) => setAnchorEl(e.currentTarget);
-  const closeMenu = () => setAnchorEl(null);
+  const chipRef = useRef<HTMLDivElement>(null);
+  const [open, setOpen] = useState(false);
+  const openMenu = () => setOpen(true);
+  const closeMenu = () => setOpen(false);
 
   const handleSelection = (selectedType: string) =>  {
     onChange(selectedType);
@@ -35,20 +38,68 @@ export function SourceTypeSelector({ value, onChange }: Props) {
     fetchTypes();
   }, []);
 
+  const iconMap: Record<string, React.ReactElement> = {
+    vehicles: <Flight fontSize="small" />,
+    employee: <People fontSize="small" />,
+    facilities: <Business fontSize="small" />,
+    facility: <Business fontSize="small" />,
+    sitrep: <Assessment fontSize="small" />,
+  };
+
+  const getIcon = (type: string) => iconMap[type.toLowerCase()] || <Category fontSize="small" />;
+
+  const label = value || 'Select Source Type';
+
   return (
     <>
-      <Button 
-        variant="contained"
-        size="small"
+      <Chip
+        ref={chipRef}
+        label={label}
         onClick={openMenu}
-        endIcon={open ? <ExpandLess /> : <ExpandMore />}
-        sx={{ marginBottom: 1, textTransform: 'capitalize' }}
+        onDelete={openMenu}
+        deleteIcon={open ? <ExpandLess /> : <ExpandMore />}
+        variant={value ? 'filled' : 'outlined'}
+        color={value ? 'primary' : 'default'}
+        sx={{
+          height: 36,
+          fontSize: '0.875rem',
+          fontWeight: 600,
+          textTransform: 'capitalize',
+          cursor: 'pointer',
+          '& .MuiChip-deleteIcon': {
+            color: value ? 'rgba(255,255,255,0.7)' : 'inherit',
+          },
+        }}
+      />
+      <Menu
+        anchorEl={chipRef.current}
+        open={open}
+        onClose={closeMenu}
+        PaperProps={{
+          sx: {
+            mt: 1,
+            minWidth: 200,
+            borderRadius: 2,
+            boxShadow: '0 4px 20px rgba(0,0,0,0.12)',
+          },
+        }}
+        transformOrigin={{ horizontal: 'left', vertical: 'top' }}
+        anchorOrigin={{ horizontal: 'left', vertical: 'bottom' }}
       >
-        {value ? `${value}` : 'Select Source Type'}
-      </Button>
-      <Menu anchorEl={anchorEl} open={open} onClose={closeMenu}>
+        <Typography variant="subtitle2" sx={{ px: 2, pt: 1, pb: 0.5, color: 'text.primary', fontWeight: 700, display: 'block' }}>
+          Source Types
+        </Typography>
         {typeList.map(t => (
-          <MenuItem key={t} onClick={() => handleSelection(t)} disableRipple>{t}</MenuItem>
+          <MenuItem
+            key={t}
+            onClick={() => handleSelection(t)}
+            selected={value === t}
+            sx={{ borderRadius: 1, mx: 0.5, textTransform: 'capitalize' }}
+          >
+            <ListItemIcon>{getIcon(t)}</ListItemIcon>
+            <ListItemText>{t}</ListItemText>
+            {value === t && <Check fontSize="small" color="primary" />}
+          </MenuItem>
         ))}
       </Menu>
     </>

--- a/common-operating-picture/ui/src/pages/SourceTypes/TdfObjectResult.tsx
+++ b/common-operating-picture/ui/src/pages/SourceTypes/TdfObjectResult.tsx
@@ -211,7 +211,7 @@ export function TdfObjectResult({ tdfObjectResponse: o, categorizedData, onFlyTo
   };
 
   const renderDetailsAndNotes = () => {
-    const details = notesOnly ? null : (displayFields?.details || []).map((field) => {
+    const details = notesOnly ? null : (displayFields?.details || []).filter(field => !field.startsWith('attr')).map((field) => {
       let value = propertyOf(o.decryptedData)(field);
       if (typeof value === 'object' && value !== null) {
         if ('country' in value) {
@@ -227,10 +227,10 @@ export function TdfObjectResult({ tdfObjectResponse: o, categorizedData, onFlyTo
       );
     });
 
-    const extractAndJoin = (attrArray: string[] | undefined, prefix: string = ''): string => {
+    const extractAndJoin = (attrArray: string[] | undefined, prefix: string = '', separator: string = '//'): string => {
         if (!attrArray || attrArray.length === 0) return '';
-        const values = attrArray.map(attrUrl => attrUrl.split('/').pop()).filter(v => v && v.trim() !== '');
-        return values.length > 0 ? `${prefix}${values.join(' // ')}` : '';
+        const values = attrArray.map(attrUrl => attrUrl.split('/').pop()?.toUpperCase()).filter((v): v is string => !!v && v.trim() !== '');
+        return values.length > 0 ? `${prefix}${values.join(separator)}` : '';
     };
 
     const notes = objectNotes.length > 0 ? (
@@ -243,9 +243,11 @@ export function TdfObjectResult({ tdfObjectResponse: o, categorizedData, onFlyTo
         }
 
         const classificationControl = extractAndJoin(parsedNote.attrClassification);
-        const needToKnowControls = extractAndJoin(parsedNote.attrNeedtoknow, classificationControl ? ' // ' : '');
-        const relToPrefix = (classificationControl || needToKnowControls) ? ' // rel to ' : parsedNote.attrRelto?.length ? 'rel to ' : '';
-        const relToControls = extractAndJoin(parsedNote.attrRelto, relToPrefix);
+        const needToKnowControls = extractAndJoin(parsedNote.attrNeedtoknow, classificationControl ? '//' : '');
+        const relToValues = extractAndJoin(parsedNote.attrRelto, '', ', ');
+        const relToControls = relToValues
+          ? `${(classificationControl || needToKnowControls) ? '//' : ''}REL TO ${relToValues}`
+          : '';
 
         // Concatenate all parts for the final display
         const controlsDisplay = `${classificationControl}${needToKnowControls}${relToControls}`;
@@ -268,9 +270,9 @@ export function TdfObjectResult({ tdfObjectResponse: o, categorizedData, onFlyTo
     return (<>{details}{notes}</>);
   };
 
-  const objClass = extractValues(o.decryptedData.attrClassification || []).split(', ');
-  const objNTK = extractValues(o.decryptedData.attrNeedToKnow || []).split(', ');
-  const objRel = extractValues(o.decryptedData.attrRelTo || []).split(', ');
+  const objClass = extractValues(o.decryptedData.attrClassification || []).split(', ').filter(Boolean);
+  const objNTK = extractValues(o.decryptedData.attrNeedToKnow || []).split(', ').filter(Boolean);
+  const objRel = extractValues(o.decryptedData.attrRelTo || []).split(', ').filter(Boolean);
 
   if (isLoading) {
     return null;

--- a/common-operating-picture/ui/src/pages/SourceTypes/index.tsx
+++ b/common-operating-picture/ui/src/pages/SourceTypes/index.tsx
@@ -4,13 +4,15 @@ import { LatLng, Map } from 'leaflet';
 import { Box, Button, Grid } from '@mui/material';
 import { AddCircle } from '@mui/icons-material';
 import { useRpcClient } from '@/hooks/useRpcClient';
+import { checkObjectEntitlements } from '@/utils/attributes';
 import { useSimulation } from '@/hooks/useSimulation';
-import { useVehicleData } from '@/hooks/useVehicleData';
+import { useVehicleData, VehicleDateFilter } from '@/hooks/useVehicleData';
 import { useEntitlements } from '@/hooks/useEntitlements';
 import { PageTitle } from '@/components/PageTitle';
 import { CopMap } from '@/components/Map/CopMap';
 import { BannerContext } from '@/contexts/BannerContext';
-import { SrcType } from '@/proto/tdf_object/v1/tdf_object_pb';
+import { SrcType, TimestampSelector } from '@/proto/tdf_object/v1/tdf_object_pb';
+import { Timestamp } from '@bufbuild/protobuf';
 import { VehicleData } from '@/types/vehicle';
 import { VehiclePopOutResponse } from '@/components/Map/Vehicle';
 import { SourceTypeProvider } from './SourceTypeProvider';
@@ -29,11 +31,12 @@ export function SourceTypes() {
   const [dialogOpen, setDialogOpen] = useState(false);
   const [srcType, setSrcType] = useState<SrcType>();
   const [poppedOutVehicle, setPoppedOutVehicle] = useState<VehiclePopOutResponse | null>(null);
-
-  const { getSrcType } = useRpcClient();
+  const [vehicleDateFilter, setVehicleDateFilter] = useState<VehicleDateFilter>();
+  const { getSrcType, queryTdfObjects } = useRpcClient();
   const { tdfObjects, setTdfObjects, activeEntitlements } = useContext(BannerContext);
   const { categorizedData } = useEntitlements();
-  const { filteredVehicleData, vehicleSrcType, fetchVehicles } = useVehicleData();
+  const isVehicleView = !srcTypeId || srcTypeId === 'vehicles';
+  const { filteredVehicleData, vehicleSrcType, fetchVehicles } = useVehicleData(vehicleDateFilter, isVehicleView);
 
   const fetchSrcType = useCallback(async (id: string) => {
     try {
@@ -128,9 +131,24 @@ export function SourceTypes() {
     }
   }, [searchParams, fetchSrcType, srcTypeId, setTdfObjects]);
 
-  const searchResultsTdfObjects = srcTypeId === 'vehicles'
-  ? [] // If the selected type is 'vehicles', show an empty list in SearchResults.
-  : tdfObjects; // Otherwise, show the actual tdfObjects (from BannerContext).
+  // Load all objects when a non-vehicle source type is selected
+  useEffect(() => {
+    if (!srcTypeId || srcTypeId === 'vehicles') return;
+
+    const tsRange = new TimestampSelector();
+    tsRange.greaterOrEqualTo = Timestamp.fromDate(new Date(0));
+
+    queryTdfObjects({ srcType: srcTypeId, tsRange })
+      .then(results => setTdfObjects(results.filter(obj => !checkObjectEntitlements(obj, activeEntitlements))))
+      .catch(err => console.error('Error fetching initial TDF objects:', err));
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [srcTypeId]);
+
+  // Only show TDF objects in search results when not viewing vehicles
+  const searchResultsTdfObjects = srcTypeId === 'vehicles' ? [] : tdfObjects;
+
+  // Only show vehicles on the map when 'vehicles' or no type is selected
+  const mapVehicleData = (!srcTypeId || srcTypeId === 'vehicles') ? filteredVehicleData : [];
 
   return (
     <>
@@ -141,7 +159,7 @@ export function SourceTypes() {
         <Grid container spacing={3}>
           <Grid item xs={12} md={7}>
             <CopMap
-              filteredVehicleData={filteredVehicleData}
+              filteredVehicleData={mapVehicleData}
               tdfObjects={tdfObjects}
               activeEntitlements={activeEntitlements}
               onMapReady={setMap}
@@ -161,14 +179,16 @@ export function SourceTypes() {
               onClearLogs={simulation.clearLogs}
             />
 
-            <Box display="flex" gap={1} mb={2}>
-              <SearchFilter map={map} />
-              <Button variant="contained" color="primary" onClick={handleDialogOpen} startIcon={<AddCircle />}>New</Button>
-            </Box>
+            {srcType && (
+              <Box display="flex" gap={1} mb={2}>
+                <SearchFilter map={map} onDateFilter={setVehicleDateFilter} />
+                <Button variant="contained" color="primary" onClick={handleDialogOpen} startIcon={<AddCircle />}>New</Button>
+              </Box>
+            )}
             <SearchResults tdfObjects={searchResultsTdfObjects} onFlyToClick={handleFlyToClick} />
           </Grid>
         </Grid>
-        <CreateDialog open={dialogOpen} onClose={handleDialogClose} />
+        {srcType && <CreateDialog open={dialogOpen} onClose={handleDialogClose} />}
         {poppedOutVehicle && (
           <VehicleDetailSidebar
             vehicle={poppedOutVehicle}


### PR DESCRIPTION
Previously, the classification selector only filtered visible objects by
classification. This change extends filtering to cover all three attribute
types across all source types:

-Vehicles: useVehicleData now applies needToKnow and relTo checks in addition to classification
- Other source types: initial auto-load in index.tsx now runs results through checkObjectEntitlements before display
- Banner.tsx: guard against NoAccess initial state rendering as UNCLASSIFIED//NOACCESS
- TdfObjectResult: add .filter(Boolean) to prevent ObjectBanner throw on empty classification; fix note control display
- MarkerLayer + TdfObjectResult: filter attr fields from detail rendering since ObjectBanner already displays classification markings